### PR TITLE
Fix reference issue in isSpaceForItem - not calling self properly

### DIFF
--- a/apis/inventory
+++ b/apis/inventory
@@ -36,7 +36,7 @@ end
 
 function Inventory:isSpaceForItem(direction)
     local current_slot = turtle.getSelectedSlot()
-    if self.hasEmptySlots() then
+    if self:hasEmptySlots() then
         return true
     end
     for slot = 1, 16, 1 do


### PR DESCRIPTION
replace `self.hasEmptySlots()` with `self:hasEmptySlots()`
